### PR TITLE
Bump socket-io-client to ~1.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "commander": "~2.6.0",
     "lodash": "~2.4.1",
     "qs": "~2.3.3",
-    "socket.io-client": "~1.2.1",
+    "socket.io-client": "~1.4.8",
     "text-table": "~0.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Node Security Project tagged engine.io-client < 1.6.9 as insecure (see https://nodesecurity.io/advisories/99).  This bumps socket.io-client to ~1.4.8 to get the latest engine.io dependency